### PR TITLE
判断bean注入时是否为空，如果为空初始化一个bean

### DIFF
--- a/src/main/java/io/dubbo/springboot/DubboAutoConfiguration.java
+++ b/src/main/java/io/dubbo/springboot/DubboAutoConfiguration.java
@@ -18,22 +18,38 @@ public class DubboAutoConfiguration {
 
     @Bean
     public ApplicationConfig requestApplicationConfig() {
-        return dubboProperties.getApplication();
+    	ApplicationConfig applicationConfig = dubboProperties.getApplication();
+    	if(applicationConfig == null){
+    		applicationConfig = new ApplicationConfig();
+    	}
+        return applicationConfig;
     }
 
     @Bean
     public RegistryConfig requestRegistryConfig() {
-        return dubboProperties.getRegistry();
+    	RegistryConfig registryConfig = dubboProperties.getRegistry();
+    	if(registryConfig == null){
+    		registryConfig = new RegistryConfig();
+    	}
+        return registryConfig;
     }
 
     @Bean
     public ProtocolConfig requestProtocolConfig() {
-        return dubboProperties.getProtocol();
+    	ProtocolConfig protocolConfig = dubboProperties.getProtocol();
+    	if(protocolConfig == null){
+    		protocolConfig = new ProtocolConfig();
+    	}
+        return protocolConfig;
     }
 
     @Bean
     public MonitorConfig requestMonitorConfig() {
-        return dubboProperties.getMonitor();
+    	MonitorConfig monitorConfig = dubboProperties.getMonitor();
+    	if(monitorConfig == null){
+    		monitorConfig = new MonitorConfig();
+    	}
+        return monitorConfig;
     }
 
 

--- a/src/main/java/io/dubbo/springboot/DubboAutoConfiguration.java
+++ b/src/main/java/io/dubbo/springboot/DubboAutoConfiguration.java
@@ -1,8 +1,12 @@
 package io.dubbo.springboot;
 
 import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ConsumerConfig;
+import com.alibaba.dubbo.config.MethodConfig;
+import com.alibaba.dubbo.config.ModuleConfig;
 import com.alibaba.dubbo.config.MonitorConfig;
 import com.alibaba.dubbo.config.ProtocolConfig;
+import com.alibaba.dubbo.config.ProviderConfig;
 import com.alibaba.dubbo.config.RegistryConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -51,6 +55,41 @@ public class DubboAutoConfiguration {
     	}
         return monitorConfig;
     }
-
+    
+    @Bean
+    public ProviderConfig requestProviderConfig(){
+    	ProviderConfig providerConfig = dubboProperties.getProvider();
+    	if(providerConfig == null){
+    		providerConfig = new ProviderConfig();
+    	}
+    	return providerConfig;
+    }
+    
+    @Bean
+    public ModuleConfig requestModuleConfig(){
+    	ModuleConfig moduleConfig = dubboProperties.getModule();
+    	if(moduleConfig == null){
+    		moduleConfig = new ModuleConfig();
+    	}
+    	return moduleConfig;
+    }
+    
+    @Bean
+    public MethodConfig requestMethodConfig(){
+    	MethodConfig  methodConfig = dubboProperties.getMethod();
+    	if(methodConfig == null){
+    		methodConfig = new MethodConfig();
+    	}
+    	return methodConfig;
+    }
+    
+    @Bean
+    public ConsumerConfig requestConsumerConfig(){
+    	ConsumerConfig consumerConfig = dubboProperties.getConsumer();
+    	if(consumerConfig == null){
+    		consumerConfig = new ConsumerConfig();
+    	}
+    	return consumerConfig;
+    }
 
 }

--- a/src/main/java/io/dubbo/springboot/DubboHolderListener.java
+++ b/src/main/java/io/dubbo/springboot/DubboHolderListener.java
@@ -9,6 +9,7 @@ import org.springframework.context.event.ContextClosedEvent;
  * @author xiaofei.wxf(teaey)
  * @since 0.0.0
  */
+@SuppressWarnings("rawtypes")
 public class DubboHolderListener implements ApplicationListener {
     private static Thread holdThread;
     private static Boolean running = Boolean.FALSE;
@@ -41,6 +42,14 @@ public class DubboHolderListener implements ApplicationListener {
                 holdThread.interrupt();
                 holdThread = null;
             }
+        }
+    }
+    
+    public static void stopApplicationContext(Boolean stop){
+    	running = stop.booleanValue();
+    	if (null != holdThread) {
+            holdThread.interrupt();
+            holdThread = null;
         }
     }
 }

--- a/src/main/java/io/dubbo/springboot/DubboProperties.java
+++ b/src/main/java/io/dubbo/springboot/DubboProperties.java
@@ -1,8 +1,12 @@
 package io.dubbo.springboot;
 
 import com.alibaba.dubbo.config.ApplicationConfig;
+import com.alibaba.dubbo.config.ConsumerConfig;
+import com.alibaba.dubbo.config.MethodConfig;
+import com.alibaba.dubbo.config.ModuleConfig;
 import com.alibaba.dubbo.config.MonitorConfig;
 import com.alibaba.dubbo.config.ProtocolConfig;
+import com.alibaba.dubbo.config.ProviderConfig;
 import com.alibaba.dubbo.config.RegistryConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -18,6 +22,14 @@ public class DubboProperties {
     private ProtocolConfig protocol;
 
     private MonitorConfig monitor;
+    
+    private ProviderConfig provider;
+    
+    private ModuleConfig module;
+    
+    private MethodConfig method;
+    
+    private ConsumerConfig consumer;
 
     public String getScan() {
         return scan;
@@ -58,4 +70,36 @@ public class DubboProperties {
     public void setMonitor(MonitorConfig monitor) {
         this.monitor = monitor;
     }
+
+	public ProviderConfig getProvider() {
+		return provider;
+	}
+
+	public void setProvider(ProviderConfig provider) {
+		this.provider = provider;
+	}
+
+	public ModuleConfig getModule() {
+		return module;
+	}
+
+	public void setModule(ModuleConfig module) {
+		this.module = module;
+	}
+
+	public MethodConfig getMethod() {
+		return method;
+	}
+
+	public void setMethod(MethodConfig method) {
+		this.method = method;
+	}
+
+	public ConsumerConfig getConsumer() {
+		return consumer;
+	}
+
+	public void setConsumer(ConsumerConfig consumer) {
+		this.consumer = consumer;
+	}
 }


### PR DESCRIPTION
当spring-boot-starter-dubbo工程打开是会报空指针错误，需要初始化一个bean